### PR TITLE
chore: promote jx3-demoapp5 to version 0.0.13 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-0.0.13-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-0.0.13-release.yaml
@@ -1,0 +1,50 @@
+# Source: jx3-demoapp5/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-11-17T23:56:42Z"
+  deletionTimestamp: null
+  name: 'jx3-demoapp5-0.0.13'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        release 0.0.13
+      sha: 96f4fa5ff4eb3c6561848e6e61d585d66d84ebea
+    - author:
+        accountReference:
+          - provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      branch: master
+      committer:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      message: |
+        ...
+      sha: 547e23cf20309d509e246dc56ca25bcd749abbd9
+  gitCloneUrl: https://github.com/myriad-personal/jx3-demoapp5.git
+  gitHttpUrl: https://github.com/myriad-personal/jx3-demoapp5
+  gitOwner: myriad-personal
+  gitRepository: jx3-demoapp5
+  name: 'jx3-demoapp5'
+  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp5/releases/tag/v0.0.13
+  version: v0.0.13
+status: {}

--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-ingress.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: jx3-demoapp5/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: jx3-demoapp5
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: jx3-demoapp5
+              servicePort: 80
+      host: jx3-demoapp5-jx-staging.apps.os.swe-test.aws.myriad.com

--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-jx3-demoapp5-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-jx3-demoapp5-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: jx3-demoapp5/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx3-demoapp5-jx3-demoapp5
+  labels:
+    draft: draft-app
+    chart: "jx3-demoapp5-0.0.13"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: jx3-demoapp5-jx3-demoapp5
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx3-demoapp5-jx3-demoapp5
+    spec:
+      serviceAccountName: jx3-demoapp5-jx3-demoapp5
+      containers:
+        - name: jx3-demoapp5
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp5:0.0.13"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.13
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-jx3-demoapp5-sa.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-jx3-demoapp5-sa.yaml
@@ -1,0 +1,8 @@
+# Source: jx3-demoapp5/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx3-demoapp5-jx3-demoapp5
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-svc.yaml
@@ -1,0 +1,21 @@
+# Source: jx3-demoapp5/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx3-demoapp5
+  labels:
+    chart: "jx3-demoapp5-0.0.13"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx3-demoapp5-jx3-demoapp5

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -17,6 +17,8 @@ repositories:
   url: https://storage.googleapis.com/jenkinsxio/charts
 - name: stable
   url: https://charts.helm.sh/stable
+- name: dev
+  url: http://bucketrepo/bucketrepo/charts
 releases:
 - chart: jenkins-x/jxboot-helmfile-resources
   version: 1.0.16
@@ -68,5 +70,9 @@ releases:
   version: 0.0.6
   name: local-external-secrets
   namespace: jx
+- chart: dev/jx3-demoapp5
+  version: 0.0.13
+  name: jx3-demoapp5
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote jx3-demoapp5 to version 0.0.13 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge