### PR TITLE
chore: promote jx3-demoapp5 to version 0.0.17 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-0.0.17-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-0.0.17-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-25T16:47:06Z"
+  creationTimestamp: "2020-11-25T17:27:40Z"
   deletionTimestamp: null
-  name: 'jx3-demoapp5-0.0.16'
+  name: 'jx3-demoapp5-0.0.17'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        release 0.0.16
-      sha: 2dccd8ecbd634d189bdfb46776c2bf19d36cc66f
+        release 0.0.17
+      sha: aaf18fdfb5088a671d98f1381221fefe5faaa2e7
     - author:
         accountReference:
           - id: troy-hart-0
@@ -40,13 +40,13 @@ spec:
         email: thart@myriad.com
         name: Troy Hart
       message: |
-        turn kaniko logging to trace
-      sha: e10e834a575b849d1e10617087f5568b59d76f8a
+        hacking
+      sha: 2294c93e6bb1ae8fb08a372bf8a6f41775f7196d
   gitCloneUrl: https://github.com/myriad-personal/jx3-demoapp5.git
   gitHttpUrl: https://github.com/myriad-personal/jx3-demoapp5
   gitOwner: myriad-personal
   gitRepository: jx3-demoapp5
   name: 'jx3-demoapp5'
-  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp5/releases/tag/v0.0.16
-  version: v0.0.16
+  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp5/releases/tag/v0.0.17
+  version: v0.0.17
 status: {}

--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-jx3-demoapp5-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-jx3-demoapp5-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-demoapp5-jx3-demoapp5
   labels:
     draft: draft-app
-    chart: "jx3-demoapp5-0.0.16"
+    chart: "jx3-demoapp5-0.0.17"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: jx3-demoapp5-jx3-demoapp5
       containers:
         - name: jx3-demoapp5
-          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp5:0.0.16"
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp5:0.0.17"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.16
+              value: 0.0.17
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-demoapp5
   labels:
-    chart: "jx3-demoapp5-0.0.16"
+    chart: "jx3-demoapp5-0.0.17"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -71,7 +71,7 @@ releases:
   name: local-external-secrets
   namespace: jx
 - chart: dev/jx3-demoapp5
-  version: 0.0.16
+  version: 0.0.17
   name: jx3-demoapp5
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote jx3-demoapp5 to version 0.0.17 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge