### PR TITLE
chore: promote jx3-demoapp5 to version 0.0.21 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-0.0.21-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-0.0.21-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-25T18:05:30Z"
+  creationTimestamp: "2020-11-25T18:30:33Z"
   deletionTimestamp: null
-  name: 'jx3-demoapp5-0.0.18'
+  name: 'jx3-demoapp5-0.0.21'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        release 0.0.18
-      sha: 9b3d2bebc81d974a4a34e92774c33952499eb2a3
+        release 0.0.21
+      sha: 9cb8a4bbfc0375215a4afa4740b871d4347eb991
     - author:
         accountReference:
           - id: troy-hart-0
@@ -41,12 +41,12 @@ spec:
         name: Troy Hart
       message: |
         hacking
-      sha: 0a01a39165ca63b3da39f3568e67c637bd205fb5
+      sha: a32014b1d8bc091111cd70415722ba805f86fa47
   gitCloneUrl: https://github.com/myriad-personal/jx3-demoapp5.git
   gitHttpUrl: https://github.com/myriad-personal/jx3-demoapp5
   gitOwner: myriad-personal
   gitRepository: jx3-demoapp5
   name: 'jx3-demoapp5'
-  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp5/releases/tag/v0.0.18
-  version: v0.0.18
+  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp5/releases/tag/v0.0.21
+  version: v0.0.21
 status: {}

--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-jx3-demoapp5-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-jx3-demoapp5-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-demoapp5-jx3-demoapp5
   labels:
     draft: draft-app
-    chart: "jx3-demoapp5-0.0.18"
+    chart: "jx3-demoapp5-0.0.21"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: jx3-demoapp5-jx3-demoapp5
       containers:
         - name: jx3-demoapp5
-          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp5:0.0.18"
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp5:0.0.21"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.18
+              value: 0.0.21
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-demoapp5
   labels:
-    chart: "jx3-demoapp5-0.0.18"
+    chart: "jx3-demoapp5-0.0.21"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -71,7 +71,7 @@ releases:
   name: local-external-secrets
   namespace: jx
 - chart: dev/jx3-demoapp5
-  version: 0.0.18
+  version: 0.0.21
   name: jx3-demoapp5
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote jx3-demoapp5 to version 0.0.21 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge