### PR TITLE
chore: promote jx3-demoapp5 to version 0.0.22 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-0.0.22-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-0.0.22-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-11-25T18:30:33Z"
+  creationTimestamp: "2020-11-25T18:41:13Z"
   deletionTimestamp: null
-  name: 'jx3-demoapp5-0.0.21'
+  name: 'jx3-demoapp5-0.0.22'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        release 0.0.21
-      sha: 9cb8a4bbfc0375215a4afa4740b871d4347eb991
+        release 0.0.22
+      sha: a4bdb5393b6e0f038829c0d2a0bf0e2a237ea4d6
     - author:
         accountReference:
           - id: troy-hart-0
@@ -41,12 +41,12 @@ spec:
         name: Troy Hart
       message: |
         hacking
-      sha: a32014b1d8bc091111cd70415722ba805f86fa47
+      sha: 08af31f387c93838ac34cac7c622da9746082a43
   gitCloneUrl: https://github.com/myriad-personal/jx3-demoapp5.git
   gitHttpUrl: https://github.com/myriad-personal/jx3-demoapp5
   gitOwner: myriad-personal
   gitRepository: jx3-demoapp5
   name: 'jx3-demoapp5'
-  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp5/releases/tag/v0.0.21
-  version: v0.0.21
+  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp5/releases/tag/v0.0.22
+  version: v0.0.22
 status: {}

--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-jx3-demoapp5-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-jx3-demoapp5-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-demoapp5-jx3-demoapp5
   labels:
     draft: draft-app
-    chart: "jx3-demoapp5-0.0.21"
+    chart: "jx3-demoapp5-0.0.22"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: jx3-demoapp5-jx3-demoapp5
       containers:
         - name: jx3-demoapp5
-          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp5:0.0.21"
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp5:0.0.22"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.21
+              value: 0.0.22
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp5/jx3-demoapp5-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-demoapp5
   labels:
-    chart: "jx3-demoapp5-0.0.21"
+    chart: "jx3-demoapp5-0.0.22"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -71,7 +71,7 @@ releases:
   name: local-external-secrets
   namespace: jx
 - chart: dev/jx3-demoapp5
-  version: 0.0.21
+  version: 0.0.22
   name: jx3-demoapp5
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote jx3-demoapp5 to version 0.0.22 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge