### PR TITLE
chore: promote jx3-demoapp6 to version 0.0.3 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-0.0.3-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-0.0.3-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-02T22:26:48Z"
+  creationTimestamp: "2020-12-03T00:16:33Z"
   deletionTimestamp: null
-  name: 'jx3-demoapp6-0.0.2'
+  name: 'jx3-demoapp6-0.0.3'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -25,7 +25,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: added variables
-      sha: 355beef1066e02dd20260a366825797a45933da4
+      sha: 9d6236c780f83851e503a0d3c0f95d03759f8203
     - author:
         accountReference:
           - id: troy-hart-0
@@ -40,13 +40,13 @@ spec:
         email: thart@myriad.com
         name: Troy Hart
       message: |
-        fix: adding charts and .jx/variables.sh
-      sha: 9378398d823bddb20ee966c530641d774cffd416
+        fix: added rest enpiont: /hola
+      sha: 9f45e8eac27d96d842796223902fa2d2c2f8abd6
   gitCloneUrl: https://github.com/myriad-personal/jx3-demoapp6.git
   gitHttpUrl: https://github.com/myriad-personal/jx3-demoapp6
   gitOwner: myriad-personal
   gitRepository: jx3-demoapp6
   name: 'jx3-demoapp6'
-  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp6/releases/tag/v0.0.2
-  version: v0.0.2
+  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp6/releases/tag/v0.0.3
+  version: v0.0.3
 status: {}

--- a/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-jx3-demoapp6-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-jx3-demoapp6-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-demoapp6-jx3-demoapp6
   labels:
     draft: draft-app
-    chart: "jx3-demoapp6-0.0.2"
+    chart: "jx3-demoapp6-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: jx3-demoapp6-jx3-demoapp6
       containers:
         - name: jx3-demoapp6
-          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp6:0.0.2"
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp6:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.2
+              value: 0.0.3
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-demoapp6
   labels:
-    chart: "jx3-demoapp6-0.0.2"
+    chart: "jx3-demoapp6-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -77,7 +77,7 @@ releases:
   name: jx3-demoapp5
   namespace: jx-staging
 - chart: dev2/jx3-demoapp6
-  version: 0.0.2
+  version: 0.0.3
   name: jx3-demoapp6
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote jx3-demoapp6 to version 0.0.3 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge