### PR TITLE
chore: promote jx3-demoapp6 to version 0.0.4 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-0.0.4-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-0.0.4-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-03T00:16:33Z"
+  creationTimestamp: "2020-12-03T15:20:45Z"
   deletionTimestamp: null
-  name: 'jx3-demoapp6-0.0.3'
+  name: 'jx3-demoapp6-0.0.4'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -25,7 +25,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: added variables
-      sha: 9d6236c780f83851e503a0d3c0f95d03759f8203
+      sha: ad584ec97cd2a4cd849e2239fa8f362c35db63ed
     - author:
         accountReference:
           - id: troy-hart-0
@@ -40,13 +40,13 @@ spec:
         email: thart@myriad.com
         name: Troy Hart
       message: |
-        fix: added rest enpiont: /hola
-      sha: 9f45e8eac27d96d842796223902fa2d2c2f8abd6
+        fix: probePath to `/actuator/health`
+      sha: 8c316e85726d88bbb51ff9396b3d2d543d6f6d0b
   gitCloneUrl: https://github.com/myriad-personal/jx3-demoapp6.git
   gitHttpUrl: https://github.com/myriad-personal/jx3-demoapp6
   gitOwner: myriad-personal
   gitRepository: jx3-demoapp6
   name: 'jx3-demoapp6'
-  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp6/releases/tag/v0.0.3
-  version: v0.0.3
+  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp6/releases/tag/v0.0.4
+  version: v0.0.4
 status: {}

--- a/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-jx3-demoapp6-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-jx3-demoapp6-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-demoapp6-jx3-demoapp6
   labels:
     draft: draft-app
-    chart: "jx3-demoapp6-0.0.3"
+    chart: "jx3-demoapp6-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,17 +24,17 @@ spec:
       serviceAccountName: jx3-demoapp6-jx3-demoapp6
       containers:
         - name: jx3-demoapp6
-          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp6:0.0.3"
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp6:0.0.4"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.3
+              value: 0.0.4
           envFrom: null
           ports:
             - containerPort: 8080
           livenessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 10
@@ -42,7 +42,7 @@ spec:
             timeoutSeconds: 1
           readinessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: 8080
             periodSeconds: 10
             successThreshold: 1

--- a/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp6/jx3-demoapp6-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-demoapp6
   labels:
-    chart: "jx3-demoapp6-0.0.3"
+    chart: "jx3-demoapp6-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -26,80 +26,57 @@ releases:
   namespace: jx
   values:
   - versionStream/charts/jenkins-x/jxboot-helmfile-resources/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jenkins-x-crds
   version: 3.0.5
   name: jenkins-x-crds
   namespace: jx
   values:
   - versionStream/charts/jx3/jenkins-x-crds/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: cdf/tekton-pipeline
   version: 0.18.0-1
   name: tekton-pipeline
   namespace: tekton-pipelines
   values:
   - versionStream/charts/cdf/tekton-pipeline/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-pipelines-visualizer
   version: 0.0.52
   name: jx-pipelines-visualizer
   namespace: jx
   values:
   - versionStream/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-preview
   version: 0.0.116
   name: jx-preview
   namespace: jx
-  forceNamespace: ""
-  skipDeps: null
 - chart: jenkins-x/lighthouse
   version: 0.0.874
   name: lighthouse
   namespace: jx
   values:
   - versionStream/charts/jenkins-x/lighthouse/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jenkins-x/bucketrepo
   version: 0.1.44
   name: bucketrepo
   namespace: jx
   values:
   - versionStream/charts/jenkins-x/bucketrepo/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-build-controller
   version: 0.0.14
   name: jx-build-controller
   namespace: jx
   values:
   - versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/local-external-secrets
   version: 0.0.6
   name: local-external-secrets
   namespace: jx
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/jx3-demoapp5
   version: 0.0.31
   name: jx3-demoapp5
   namespace: jx-staging
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/jx3-demoapp6
-  version: 0.0.3
+  version: 0.0.4
   name: jx3-demoapp6
   namespace: jx-staging
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
 missingFileHandler: ""
-renderedvalues: {}


### PR DESCRIPTION
chore: promote jx3-demoapp6 to version 0.0.4 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge