### PR TITLE
chore: promote jx3-demoapp5 to version 0.0.31 in Production environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -26,86 +26,61 @@ releases:
   namespace: jx
   values:
   - versionStream/charts/jenkins-x/jxboot-helmfile-resources/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jenkins-x-crds
   version: 3.0.5
   name: jenkins-x-crds
   namespace: jx
   values:
   - versionStream/charts/jx3/jenkins-x-crds/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: cdf/tekton-pipeline
   version: 0.18.0-1
   name: tekton-pipeline
   namespace: tekton-pipelines
   values:
   - versionStream/charts/cdf/tekton-pipeline/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-pipelines-visualizer
   version: 0.0.52
   name: jx-pipelines-visualizer
   namespace: jx
   values:
   - versionStream/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-preview
   version: 0.0.116
   name: jx-preview
   namespace: jx
-  forceNamespace: ""
-  skipDeps: null
 - chart: jenkins-x/lighthouse
   version: 0.0.874
   name: lighthouse
   namespace: jx
   values:
   - versionStream/charts/jenkins-x/lighthouse/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jenkins-x/bucketrepo
   version: 0.1.44
   name: bucketrepo
   namespace: jx
   values:
   - versionStream/charts/jenkins-x/bucketrepo/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-build-controller
   version: 0.0.14
   name: jx-build-controller
   namespace: jx
   values:
   - versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/local-external-secrets
   version: 0.0.6
   name: local-external-secrets
   namespace: jx
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/jx3-demoapp5
   version: 0.0.31
   name: jx3-demoapp5
   namespace: jx-staging
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/jx3-demoapp6
   version: 0.0.4
   name: jx3-demoapp6
   namespace: jx-staging
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/jx3-demoapp5
   version: 0.0.31
   name: jx3-demoapp5
   namespace: jx-production
-  forceNamespace: ""
-  skipDeps: null
 templates: {}
 missingFileHandler: ""
-renderedvalues: {}


### PR DESCRIPTION
chore: promote jx3-demoapp5 to version 0.0.31 in Production environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge