### PR TITLE
chore: promote jx3-demoapp6 to version 0.0.4 in Production environment

### DIFF
--- a/config-root/namespaces/jx-production/jx3-demoapp6/jx3-demoapp6-0.0.4-release.yaml
+++ b/config-root/namespaces/jx-production/jx3-demoapp6/jx3-demoapp6-0.0.4-release.yaml
@@ -1,0 +1,52 @@
+# Source: jx3-demoapp6/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-03T15:20:45Z"
+  deletionTimestamp: null
+  name: 'jx3-demoapp6-0.0.4'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: added variables
+      sha: ad584ec97cd2a4cd849e2239fa8f362c35db63ed
+    - author:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      branch: master
+      committer:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      message: |
+        fix: probePath to `/actuator/health`
+      sha: 8c316e85726d88bbb51ff9396b3d2d543d6f6d0b
+  gitCloneUrl: https://github.com/myriad-personal/jx3-demoapp6.git
+  gitHttpUrl: https://github.com/myriad-personal/jx3-demoapp6
+  gitOwner: myriad-personal
+  gitRepository: jx3-demoapp6
+  name: 'jx3-demoapp6'
+  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp6/releases/tag/v0.0.4
+  version: v0.0.4
+status: {}

--- a/config-root/namespaces/jx-production/jx3-demoapp6/jx3-demoapp6-ingress.yaml
+++ b/config-root/namespaces/jx-production/jx3-demoapp6/jx3-demoapp6-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: jx3-demoapp6/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: jx3-demoapp6
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: jx3-demoapp6
+              servicePort: 80
+      host: jx3-demoapp6-jx-production.apps.os.swe-test.aws.myriad.com

--- a/config-root/namespaces/jx-production/jx3-demoapp6/jx3-demoapp6-jx3-demoapp6-deploy.yaml
+++ b/config-root/namespaces/jx-production/jx3-demoapp6/jx3-demoapp6-jx3-demoapp6-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: jx3-demoapp6/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx3-demoapp6-jx3-demoapp6
+  labels:
+    draft: draft-app
+    chart: "jx3-demoapp6-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: jx3-demoapp6-jx3-demoapp6
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx3-demoapp6-jx3-demoapp6
+    spec:
+      serviceAccountName: jx3-demoapp6-jx3-demoapp6
+      containers:
+        - name: jx3-demoapp6
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp6:0.0.4"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.4
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/jx3-demoapp6/jx3-demoapp6-jx3-demoapp6-sa.yaml
+++ b/config-root/namespaces/jx-production/jx3-demoapp6/jx3-demoapp6-jx3-demoapp6-sa.yaml
@@ -1,0 +1,8 @@
+# Source: jx3-demoapp6/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx3-demoapp6-jx3-demoapp6
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/jx3-demoapp6/jx3-demoapp6-svc.yaml
+++ b/config-root/namespaces/jx-production/jx3-demoapp6/jx3-demoapp6-svc.yaml
@@ -1,0 +1,21 @@
+# Source: jx3-demoapp6/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx3-demoapp6
+  labels:
+    chart: "jx3-demoapp6-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx3-demoapp6-jx3-demoapp6

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -26,86 +26,65 @@ releases:
   namespace: jx
   values:
   - versionStream/charts/jenkins-x/jxboot-helmfile-resources/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jenkins-x-crds
   version: 3.0.5
   name: jenkins-x-crds
   namespace: jx
   values:
   - versionStream/charts/jx3/jenkins-x-crds/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: cdf/tekton-pipeline
   version: 0.18.0-1
   name: tekton-pipeline
   namespace: tekton-pipelines
   values:
   - versionStream/charts/cdf/tekton-pipeline/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-pipelines-visualizer
   version: 0.0.52
   name: jx-pipelines-visualizer
   namespace: jx
   values:
   - versionStream/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-preview
   version: 0.0.116
   name: jx-preview
   namespace: jx
-  forceNamespace: ""
-  skipDeps: null
 - chart: jenkins-x/lighthouse
   version: 0.0.874
   name: lighthouse
   namespace: jx
   values:
   - versionStream/charts/jenkins-x/lighthouse/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jenkins-x/bucketrepo
   version: 0.1.44
   name: bucketrepo
   namespace: jx
   values:
   - versionStream/charts/jenkins-x/bucketrepo/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/jx-build-controller
   version: 0.0.14
   name: jx-build-controller
   namespace: jx
   values:
   - versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
-  forceNamespace: ""
-  skipDeps: null
 - chart: jx3/local-external-secrets
   version: 0.0.6
   name: local-external-secrets
   namespace: jx
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/jx3-demoapp5
   version: 0.0.31
   name: jx3-demoapp5
   namespace: jx-staging
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/jx3-demoapp6
   version: 0.0.4
   name: jx3-demoapp6
   namespace: jx-staging
-  forceNamespace: ""
-  skipDeps: null
 - chart: dev/jx3-demoapp5
   version: 0.0.31
   name: jx3-demoapp5
   namespace: jx-production
-  forceNamespace: ""
-  skipDeps: null
+- chart: dev/jx3-demoapp6
+  version: 0.0.4
+  name: jx3-demoapp6
+  namespace: jx-production
 templates: {}
 missingFileHandler: ""
-renderedvalues: {}


### PR DESCRIPTION
chore: promote jx3-demoapp6 to version 0.0.4 in Production environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge