### PR TITLE
chore: promote jx3-demoapp1 to version 0.0.4 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-0.0.4-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-0.0.4-release.yaml
@@ -1,0 +1,52 @@
+# Source: jx3-demoapp1/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-04T19:20:02Z"
+  deletionTimestamp: null
+  name: 'jx3-demoapp1-0.0.4'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        release 0.0.4
+      sha: 8c3bb67c6efa945fda3348943f2e615aadebac6a
+    - author:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      branch: master
+      committer:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      message: |
+        fix: kaniko flags to work with insecure registry
+      sha: fcbce858b1c5693651c967222320f5a4b832e27b
+  gitCloneUrl: https://github.com/myriad-personal/jx3-demoapp1.git
+  gitHttpUrl: https://github.com/myriad-personal/jx3-demoapp1
+  gitOwner: myriad-personal
+  gitRepository: jx3-demoapp1
+  name: 'jx3-demoapp1'
+  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp1/releases/tag/v0.0.4
+  version: v0.0.4
+status: {}

--- a/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-ingress.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: jx3-demoapp1/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: jx3-demoapp1
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: jx3-demoapp1
+              servicePort: 80
+      host: jx3-demoapp1-jx-staging.apps.os.swe-test.aws.myriad.com

--- a/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-jx3-demoapp1-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-jx3-demoapp1-deploy.yaml
@@ -1,0 +1,55 @@
+# Source: jx3-demoapp1/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx3-demoapp1-jx3-demoapp1
+  labels:
+    draft: draft-app
+    chart: "jx3-demoapp1-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: jx3-demoapp1-jx3-demoapp1
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx3-demoapp1-jx3-demoapp1
+    spec:
+      containers:
+        - name: jx3-demoapp1
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp1:0.0.4"
+          imagePullPolicy: IfNotPresent
+          env:
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-svc.yaml
@@ -1,0 +1,21 @@
+# Source: jx3-demoapp1/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx3-demoapp1
+  labels:
+    chart: "jx3-demoapp1-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx3-demoapp1-jx3-demoapp1

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -86,5 +86,9 @@ releases:
   version: 0.0.4
   name: jx3-demoapp6
   namespace: jx-production
+- chart: dev/jx3-demoapp1
+  version: 0.0.4
+  name: jx3-demoapp1
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote jx3-demoapp1 to version 0.0.4 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge