### PR TITLE
chore: promote jx3-demoapp4 to version 1.0.5 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -86,5 +86,9 @@ releases:
   version: 0.0.4
   name: jx3-demoapp6
   namespace: jx-production
+- chart: dev/jx3-demoapp4
+  version: 1.0.5
+  name: jx3-demoapp4
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote jx3-demoapp4 to version 1.0.5 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge