### PR TITLE
chore: promote jx3-demoapp1 to version 0.0.5 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-0.0.5-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-0.0.5-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-04T19:20:02Z"
+  creationTimestamp: "2020-12-04T19:35:13Z"
   deletionTimestamp: null
-  name: 'jx3-demoapp1-0.0.4'
+  name: 'jx3-demoapp1-0.0.5'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        release 0.0.4
-      sha: 8c3bb67c6efa945fda3348943f2e615aadebac6a
+        release 0.0.5
+      sha: eadb0fc640ecf3e7a8f6f03d9d74183209019d70
     - author:
         accountReference:
           - id: troy-hart-0
@@ -40,13 +40,13 @@ spec:
         email: thart@myriad.com
         name: Troy Hart
       message: |
-        fix: kaniko flags to work with insecure registry
-      sha: fcbce858b1c5693651c967222320f5a4b832e27b
+        fix: broken build
+      sha: 97d6693804849d440bffee98d475f9e57ea72390
   gitCloneUrl: https://github.com/myriad-personal/jx3-demoapp1.git
   gitHttpUrl: https://github.com/myriad-personal/jx3-demoapp1
   gitOwner: myriad-personal
   gitRepository: jx3-demoapp1
   name: 'jx3-demoapp1'
-  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp1/releases/tag/v0.0.4
-  version: v0.0.4
+  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp1/releases/tag/v0.0.5
+  version: v0.0.5
 status: {}

--- a/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-jx3-demoapp1-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-jx3-demoapp1-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-demoapp1-jx3-demoapp1
   labels:
     draft: draft-app
-    chart: "jx3-demoapp1-0.0.4"
+    chart: "jx3-demoapp1-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: jx3-demoapp1
-          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp1:0.0.4"
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp1:0.0.5"
           imagePullPolicy: IfNotPresent
           env:
           envFrom: null

--- a/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp1/jx3-demoapp1-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-demoapp1
   labels:
-    chart: "jx3-demoapp1-0.0.4"
+    chart: "jx3-demoapp1-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -87,7 +87,7 @@ releases:
   name: jx3-demoapp6
   namespace: jx-production
 - chart: dev/jx3-demoapp1
-  version: 0.0.4
+  version: 0.0.5
   name: jx3-demoapp1
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote jx3-demoapp1 to version 0.0.5 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge