### PR TITLE
chore: promote jx3-demoapp4 to version 1.0.6 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-demoapp4/jx3-demoapp4-1.0.6-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp4/jx3-demoapp4-1.0.6-release.yaml
@@ -1,0 +1,52 @@
+# Source: jx3-demoapp4/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-04T19:54:59Z"
+  deletionTimestamp: null
+  name: 'jx3-demoapp4-1.0.6'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        release 1.0.6
+      sha: 8ea2dc7d6c7b905e7705d52f31b11eeec6250303
+    - author:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      branch: master
+      committer:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      message: |
+        fix: Controller -> RestController...
+      sha: c7e72aa58613153cd3fd0c9dfdd930e090c23c44
+  gitCloneUrl: https://github.com/myriad-personal/jx3-demoapp4.git
+  gitHttpUrl: https://github.com/myriad-personal/jx3-demoapp4
+  gitOwner: myriad-personal
+  gitRepository: jx3-demoapp4
+  name: 'jx3-demoapp4'
+  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp4/releases/tag/v1.0.6
+  version: v1.0.6
+status: {}

--- a/config-root/namespaces/jx-staging/jx3-demoapp4/jx3-demoapp4-ingress.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp4/jx3-demoapp4-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: jx3-demoapp4/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: jx3-demoapp4
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: jx3-demoapp4
+              servicePort: 80
+      host: jx3-demoapp4-jx-staging.apps.os.swe-test.aws.myriad.com

--- a/config-root/namespaces/jx-staging/jx3-demoapp4/jx3-demoapp4-jx3-demoapp4-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp4/jx3-demoapp4-jx3-demoapp4-deploy.yaml
@@ -1,0 +1,58 @@
+# Source: jx3-demoapp4/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx3-demoapp4-jx3-demoapp4
+  labels:
+    draft: draft-app
+    chart: "jx3-demoapp4-1.0.6"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: jx3-demoapp4-jx3-demoapp4
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx3-demoapp4-jx3-demoapp4
+    spec:
+      serviceAccountName: jx3-demoapp4-jx3-demoapp4
+      containers:
+        - name: jx3-demoapp4
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp4:1.0.6"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 1.0.6
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/jx3-demoapp4/jx3-demoapp4-jx3-demoapp4-sa.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp4/jx3-demoapp4-jx3-demoapp4-sa.yaml
@@ -1,0 +1,8 @@
+# Source: jx3-demoapp4/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx3-demoapp4-jx3-demoapp4
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/jx3-demoapp4/jx3-demoapp4-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp4/jx3-demoapp4-svc.yaml
@@ -1,0 +1,21 @@
+# Source: jx3-demoapp4/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx3-demoapp4
+  labels:
+    chart: "jx3-demoapp4-1.0.6"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx3-demoapp4-jx3-demoapp4

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -90,5 +90,9 @@ releases:
   version: 0.0.5
   name: jx3-demoapp1
   namespace: jx-staging
+- chart: dev/jx3-demoapp4
+  version: 1.0.6
+  name: jx3-demoapp4
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote jx3-demoapp4 to version 1.0.6 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge