### PR TITLE
chore: promote jx3-springdemo2 to version 1.0.10 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-1.0.10-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-1.0.10-release.yaml
@@ -1,0 +1,52 @@
+# Source: jx3-springdemo2/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-04T20:59:44Z"
+  deletionTimestamp: null
+  name: 'jx3-springdemo2-1.0.10'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        accountReference:
+          - id: jenkins-x-bot-0
+            provider: jenkins.io/git-github-userid
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        release 1.0.10
+      sha: d334c846e05e3041d1efdcbb18a89a3ac6e917bc
+    - author:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      branch: master
+      committer:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      message: |
+        fix: jar deployment
+      sha: 3c3313cfddcd7bdfb0fffe47492388f55535d638
+  gitCloneUrl: https://github.com/myriad-personal/jx3-springdemo2.git
+  gitHttpUrl: https://github.com/myriad-personal/jx3-springdemo2
+  gitOwner: myriad-personal
+  gitRepository: jx3-springdemo2
+  name: 'jx3-springdemo2'
+  releaseNotesURL: https://github.com/myriad-personal/jx3-springdemo2/releases/tag/v1.0.10
+  version: v1.0.10
+status: {}

--- a/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-ingress.yaml
+++ b/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: jx3-springdemo2/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: jx3-springdemo2
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: jx3-springdemo2
+              servicePort: 80
+      host: jx3-springdemo2-jx-staging.apps.os.swe-test.aws.myriad.com

--- a/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-jx3-springdemo2-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-jx3-springdemo2-deploy.yaml
@@ -1,0 +1,55 @@
+# Source: jx3-springdemo2/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx3-springdemo2-jx3-springdemo2
+  labels:
+    draft: draft-app
+    chart: "jx3-springdemo2-1.0.10"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: jx3-springdemo2-jx3-springdemo2
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx3-springdemo2-jx3-springdemo2
+    spec:
+      containers:
+        - name: jx3-springdemo2
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-springdemo2:1.0.10"
+          imagePullPolicy: IfNotPresent
+          env:
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-svc.yaml
@@ -1,0 +1,21 @@
+# Source: jx3-springdemo2/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx3-springdemo2
+  labels:
+    chart: "jx3-springdemo2-1.0.10"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx3-springdemo2-jx3-springdemo2

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -94,5 +94,9 @@ releases:
   version: 1.0.6
   name: jx3-demoapp4
   namespace: jx-staging
+- chart: dev/jx3-springdemo2
+  version: 1.0.10
+  name: jx3-springdemo2
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote jx3-springdemo2 to version 1.0.10 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge