### PR TITLE
chore: promote jx3-springdemo2 to version 1.0.11 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-1.0.11-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-1.0.11-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-04T20:59:44Z"
+  creationTimestamp: "2020-12-04T21:02:53Z"
   deletionTimestamp: null
-  name: 'jx3-springdemo2-1.0.10'
+  name: 'jx3-springdemo2-1.0.11'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        release 1.0.10
-      sha: d334c846e05e3041d1efdcbb18a89a3ac6e917bc
+        release 1.0.11
+      sha: 0c3fe3e12b75a73935e22fde21e1fbd2032b42a0
     - author:
         accountReference:
           - id: troy-hart-0
@@ -40,13 +40,13 @@ spec:
         email: thart@myriad.com
         name: Troy Hart
       message: |
-        fix: jar deployment
-      sha: 3c3313cfddcd7bdfb0fffe47492388f55535d638
+        fix: remove debugging
+      sha: 584fd6005c1f7eefbd64d8eb295d89fcfae0d411
   gitCloneUrl: https://github.com/myriad-personal/jx3-springdemo2.git
   gitHttpUrl: https://github.com/myriad-personal/jx3-springdemo2
   gitOwner: myriad-personal
   gitRepository: jx3-springdemo2
   name: 'jx3-springdemo2'
-  releaseNotesURL: https://github.com/myriad-personal/jx3-springdemo2/releases/tag/v1.0.10
-  version: v1.0.10
+  releaseNotesURL: https://github.com/myriad-personal/jx3-springdemo2/releases/tag/v1.0.11
+  version: v1.0.11
 status: {}

--- a/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-jx3-springdemo2-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-jx3-springdemo2-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-springdemo2-jx3-springdemo2
   labels:
     draft: draft-app
-    chart: "jx3-springdemo2-1.0.10"
+    chart: "jx3-springdemo2-1.0.11"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: jx3-springdemo2
-          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-springdemo2:1.0.10"
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-springdemo2:1.0.11"
           imagePullPolicy: IfNotPresent
           env:
           envFrom: null

--- a/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-springdemo2
   labels:
-    chart: "jx3-springdemo2-1.0.10"
+    chart: "jx3-springdemo2-1.0.11"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -95,7 +95,7 @@ releases:
   name: jx3-demoapp4
   namespace: jx-staging
 - chart: dev/jx3-springdemo2
-  version: 1.0.10
+  version: 1.0.11
   name: jx3-springdemo2
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote jx3-springdemo2 to version 1.0.11 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge