### PR TITLE
chore: promote jx3-springdemo2 to version 1.0.12 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-1.0.12-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-1.0.12-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2020-12-04T21:02:53Z"
+  creationTimestamp: "2020-12-04T21:08:21Z"
   deletionTimestamp: null
-  name: 'jx3-springdemo2-1.0.11'
+  name: 'jx3-springdemo2-1.0.12'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -24,8 +24,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        release 1.0.11
-      sha: 0c3fe3e12b75a73935e22fde21e1fbd2032b42a0
+        release 1.0.12
+      sha: a845a129e7cd0f9b2105274eeaeaab7324a072db
     - author:
         accountReference:
           - id: troy-hart-0
@@ -40,13 +40,13 @@ spec:
         email: thart@myriad.com
         name: Troy Hart
       message: |
-        fix: remove debugging
-      sha: 584fd6005c1f7eefbd64d8eb295d89fcfae0d411
+        fix: probePath: /actuator/health
+      sha: c08b98a75a625479d311a64ccdc9dd1eadb5576a
   gitCloneUrl: https://github.com/myriad-personal/jx3-springdemo2.git
   gitHttpUrl: https://github.com/myriad-personal/jx3-springdemo2
   gitOwner: myriad-personal
   gitRepository: jx3-springdemo2
   name: 'jx3-springdemo2'
-  releaseNotesURL: https://github.com/myriad-personal/jx3-springdemo2/releases/tag/v1.0.11
-  version: v1.0.11
+  releaseNotesURL: https://github.com/myriad-personal/jx3-springdemo2/releases/tag/v1.0.12
+  version: v1.0.12
 status: {}

--- a/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-jx3-springdemo2-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-jx3-springdemo2-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-springdemo2-jx3-springdemo2
   labels:
     draft: draft-app
-    chart: "jx3-springdemo2-1.0.11"
+    chart: "jx3-springdemo2-1.0.12"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: jx3-springdemo2
-          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-springdemo2:1.0.11"
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-springdemo2:1.0.12"
           imagePullPolicy: IfNotPresent
           env:
           envFrom: null
@@ -31,7 +31,7 @@ spec:
             - containerPort: 8080
           livenessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: 8080
             initialDelaySeconds: 60
             periodSeconds: 10
@@ -39,7 +39,7 @@ spec:
             timeoutSeconds: 1
           readinessProbe:
             httpGet:
-              path: /
+              path: /actuator/health
               port: 8080
             periodSeconds: 10
             successThreshold: 1

--- a/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-springdemo2/jx3-springdemo2-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-springdemo2
   labels:
-    chart: "jx3-springdemo2-1.0.11"
+    chart: "jx3-springdemo2-1.0.12"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -95,7 +95,7 @@ releases:
   name: jx3-demoapp4
   namespace: jx-staging
 - chart: dev/jx3-springdemo2
-  version: 1.0.11
+  version: 1.0.12
   name: jx3-springdemo2
   namespace: jx-staging
 templates: {}


### PR DESCRIPTION
chore: promote jx3-springdemo2 to version 1.0.12 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge