### PR TITLE
chore: promote jx3-demoapp2 to version 0.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-demoapp2/jx3-demoapp2-0.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp2/jx3-demoapp2-0.0.1-release.yaml
@@ -1,0 +1,82 @@
+# Source: jx3-demoapp2/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-04T22:43:24Z"
+  deletionTimestamp: null
+  name: 'jx3-demoapp2-0.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      branch: master
+      committer:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      message: |
+        ...
+      sha: c46e6c84d56aa3cbd6a40794ea2b4c80238d6a96
+    - author:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      branch: master
+      committer:
+        accountReference:
+          - provider: jenkins.io/git-github-userid
+        email: noreply@github.com
+        name: GitHub
+      message: Update README.md
+      sha: cd79554846c5967436dde6048f03e5ae6d00761d
+    - author:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      branch: master
+      committer:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      message: |
+        fix: installed stalled and left these
+      sha: e9621e5bb68a3c6235453df64cc08022ac8392e4
+    - author:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      branch: master
+      committer:
+        accountReference:
+          - id: troy-hart-0
+            provider: jenkins.io/git-github-userid
+        email: thart@myriad.com
+        name: Troy Hart
+      message: |
+        fix: kaniko flags to work with insecure registry
+      sha: 1ffd05b95b361a004053fab36229ed4fe83ed844
+  gitCloneUrl: https://github.com/myriad-personal/jx3-demoapp2.git
+  gitHttpUrl: https://github.com/myriad-personal/jx3-demoapp2
+  gitOwner: myriad-personal
+  gitRepository: jx3-demoapp2
+  name: 'jx3-demoapp2'
+  releaseNotesURL: https://github.com/myriad-personal/jx3-demoapp2/releases/tag/v0.0.1
+  version: v0.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/jx3-demoapp2/jx3-demoapp2-ingress.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp2/jx3-demoapp2-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: jx3-demoapp2/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: jx3-demoapp2
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: jx3-demoapp2
+              servicePort: 80
+      host: jx3-demoapp2-jx-staging.apps.os.swe-test.aws.myriad.com

--- a/config-root/namespaces/jx-staging/jx3-demoapp2/jx3-demoapp2-jx3-demoapp2-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp2/jx3-demoapp2-jx3-demoapp2-deploy.yaml
@@ -1,0 +1,55 @@
+# Source: jx3-demoapp2/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx3-demoapp2-jx3-demoapp2
+  labels:
+    draft: draft-app
+    chart: "jx3-demoapp2-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: jx3-demoapp2-jx3-demoapp2
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx3-demoapp2-jx3-demoapp2
+    spec:
+      containers:
+        - name: jx3-demoapp2
+          image: "image-registry.openshift-image-registry.svc:5000/jx/jx3-demoapp2:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/jx3-demoapp2/jx3-demoapp2-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-demoapp2/jx3-demoapp2-svc.yaml
@@ -1,0 +1,21 @@
+# Source: jx3-demoapp2/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx3-demoapp2
+  labels:
+    chart: "jx3-demoapp2-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx3-demoapp2-jx3-demoapp2

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -98,5 +98,9 @@ releases:
   version: 1.0.12
   name: jx3-springdemo2
   namespace: jx-staging
+- chart: dev/jx3-demoapp2
+  version: 0.0.1
+  name: jx3-demoapp2
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote jx3-demoapp2 to version 0.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge