### PR TITLE
chore: promote jx3-demoapp1 to version 0.0.6 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -16,5 +16,9 @@ releases:
   version: 0.0.33
   name: jx3-demoapp5
   namespace: jx-staging
+- chart: dev/jx3-demoapp1
+  version: 0.0.6
+  name: jx3-demoapp1
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote jx3-demoapp1 to version 0.0.6 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge